### PR TITLE
Fixed age to be a string in offender.

### DIFF
--- a/LibrsModels/Classes/Offender.cs
+++ b/LibrsModels/Classes/Offender.cs
@@ -11,7 +11,7 @@ namespace LibrsModels.Classes
 
         [JsonProperty("offenderSeqNum")] public int? OffenderSeqNum { get; set; }
 
-        [JsonProperty("age")] public int? Age { get; set; }
+        [JsonProperty("age")] public string Age { get; set; }
         [JsonProperty("estimatedAge")] public bool EstimatedAge { get; set; } = false;
 
         [JsonProperty("dob")] public DateTime? Dob { get; set; }
@@ -44,7 +44,7 @@ namespace LibrsModels.Classes
             Ethnicity = Ethnicity.PadR(1);
         }
 
-        private string PadOffenderAge(string age)
+        public string PadOffenderAge(string age)
         {
             if (age.IsNullBlankOrEmpty()) return "".PadR(3);
             if (age.Contains('E'))


### PR DESCRIPTION
# Changes:
- Changed offender age from nullable int to string and plan to change the documentation to mention string to be consistent with Victim and Arrestee.
- Made PadOffenderAge() function public.