### PR TITLE
JSON model and saving for Victim object - Injury type is incorrect

### DIFF
--- a/LibrsModels/Classes/Victim.cs
+++ b/LibrsModels/Classes/Victim.cs
@@ -62,7 +62,7 @@ namespace LibrsModels.Classes
 
         [JsonProperty("officerOri")] public string OfficerOri { get; set; } = "         ";
 
-        [JsonProperty("injuryType")] public string InjuryType { get; set; } = " ";
+        [JsonProperty("injuryType")] public List<string> InjuryType { get; set; } = new List<string>();
         
         [JsonProperty("relatedOffenders")] public List<VicOff> RelatedOffenders { get; set; }
         

--- a/LibrsModels/LibrsDataModels.csproj
+++ b/LibrsModels/LibrsDataModels.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <PackageVersion>1.0.11</PackageVersion>
+        <PackageVersion>1.0.28</PackageVersion>
         <Title>LibrsDataModels</Title>
         <Authors>Technology Engineers, Inc.</Authors>
         <Description>Contains C# Objects for LIBRS State Reporting. </Description>


### PR DESCRIPTION
# Changes
- Fixed JSON victim injury types to be a List<string>.

# Asana Tasks Involved:
- [JSON model and saving for Victim object - Injury type is incorrect](https://app.asana.com/1/121567981976/project/1203938031651467/task/1212399258123419?focus=true)

# Notes (@dougbarbin):
- I will also make a PR for WINLIBRS that references this where I had to fix some places in code to accommodate this change.
- I need to see what it will affect if I update the .NET 8 version (enhance). I will probably have to fix things in Track Crime if/when I do.